### PR TITLE
fix: race condition with async state, on url change

### DIFF
--- a/src/useAssets.ts
+++ b/src/useAssets.ts
@@ -12,9 +12,24 @@ export function useAssets<T>(urls: AssetUrl) {
   const [state, setState, thenable] = useAssetState<T, AssetUrl>(urls, isLoaded, load, resolve);
 
   useEffect(() => {
-    thenable
-      .then(data => setState({status: 'loaded', isLoaded: true, error: null, data}))
-      .catch(error => setState({status: 'error', isLoaded: false, error, data: null}));
+    const pending = new WeakSet([thenable]);
+    (async () => {
+      try {
+        const data = await thenable;
+        if (pending.has(thenable)) {
+          setState({status: 'loaded', isLoaded: true, error: null, data});
+        }
+      } catch (error: unknown) {
+        if (pending.has(thenable)) {
+          setState({
+            status: 'error',
+            isLoaded: false,
+            error: error instanceof Error ? error : new Error(String(error)),
+            data: null,
+          });
+        }
+      }
+    })();
   }, [setState, thenable]);
 
   return state;


### PR DESCRIPTION
Fix for async state being updated incorrectly if urls change and the loads come in out of order.